### PR TITLE
Laravel 5.7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Laravel 5.5/5.6 Front-end Preset For Tabler Dashboard UI Kit
+# Laravel 5.5+ Front-end Preset For Tabler Dashboard UI Kit
 
 [![Latest Stable Version](https://poser.pugx.org/cesaramirez/laravel-tabler/v/stable)](https://packagist.org/packages/cesaramirez/laravel-tabler)
 
-Preset for [Tabler](https://tabler.github.io/) scaffolding on new Laravel 5.5/5.6 project.
+Preset for [Tabler](https://tabler.github.io/) scaffolding on a new Laravel 5.5 or above project.
 
 ## Usage
 
-1.  Fresh install Laravel 5.5/5.6 and `cd` to your app.
-2.  Install this preset via `composer require cesaramirez/laravel-tabler`. Laravel 5.5/5.6 will automatically discover this package. No need to register the service provider.
+1.  Fresh install Laravel 5.5 or above and `cd` to your app.
+2.  Install this preset via `composer require cesaramirez/laravel-tabler`. Laravel 5.5+ will automatically discover this package. No need to register the service provider.
 3.  Use `php artisan preset tabler` for basic Tabler preset. **OR** Use `php artisan preset tabler-auth` for basic preset, Auth route entry and Tabler Auth views in one go. (**NOTE**: If you run this command several times, be sure to clean up the duplicate Auth entries in `routes/web.php`)
 4.  `yarn`
 5.  `yarn dev` or `yarn watch`

--- a/src/TablerPreset.php
+++ b/src/TablerPreset.php
@@ -109,7 +109,7 @@ class TablerPreset extends Preset
             return resource_path($path);
         }
 
-        return static::getResourcePath('assets/' . $path);
+        return resource_path('assets/' . $path);
     }
 
     /**

--- a/src/TablerPreset.php
+++ b/src/TablerPreset.php
@@ -48,10 +48,10 @@ class TablerPreset extends Preset
      */
     protected static function updateAssets()
     {
-        copy(__DIR__.'/tabler-stubs/sass/app.scss', resource_path('assets/sass/app.scss'));
-        copy(__DIR__.'/tabler-stubs/sass/_variables.scss', resource_path('assets/sass/_variables.scss'));
-        (new Filesystem())->copyDirectory(__DIR__.'/tabler-stubs/sass/tabler', resource_path('assets/sass/tabler'));
-        (new Filesystem())->copyDirectory(__DIR__.'/tabler-stubs/fonts', resource_path('assets/fonts'));
+        copy(__DIR__.'/tabler-stubs/sass/app.scss', static::getResourcePath('sass/app.scss'));
+        copy(__DIR__.'/tabler-stubs/sass/_variables.scss', static::getResourcePath('sass/_variables.scss'));
+        (new Filesystem())->copyDirectory(__DIR__.'/tabler-stubs/sass/tabler', static::getResourcePath('sass/tabler'));
+        (new Filesystem())->copyDirectory(__DIR__.'/tabler-stubs/fonts', static::getResourcePath('fonts'));
     }
 
     /**
@@ -60,7 +60,12 @@ class TablerPreset extends Preset
     protected static function updateBootstrapping()
     {
         copy(__DIR__.'/tabler-stubs/webpack.mix.js', base_path('webpack.mix.js'));
-        copy(__DIR__.'/tabler-stubs/bootstrap.js', resource_path('assets/js/bootstrap.js'));
+
+        if (self::isLaravel57orUp()) {
+            file_put_contents(base_path('webpack.mix.js'), str_replace("assets/", "", file_get_contents(base_path('webpack.mix.js'))));
+        }
+ 
+        copy(__DIR__.'/tabler-stubs/bootstrap.js', static::getResourcePath('js/bootstrap.js'));
     }
 
     /**
@@ -89,5 +94,31 @@ class TablerPreset extends Preset
             Container::getInstance()->getNamespace(),
             file_get_contents(__DIR__.'/tabler-stubs/controllers/HomeController.stub')
         );
+    }
+
+    /**
+     * Gets resource path depending on version of Laravel
+     *
+     * @param string $path
+     * @return string
+     */
+    protected static function getResourcePath($path = '')
+    {
+
+        if (self::isLaravel57orUp()) {
+            return resource_path($path);
+        }
+
+        return static::getResourcePath('assets/' . $path);
+    }
+
+    /**
+     * Is running in Laravel 5.7 or up?
+     * 
+     * @return bool
+     */
+    protected static function isLaravel57orUp()
+    {
+        return (int)str_replace('.', '', app()->version()) >= 570;
     }
 }

--- a/src/TablerPreset.php
+++ b/src/TablerPreset.php
@@ -62,7 +62,13 @@ class TablerPreset extends Preset
         copy(__DIR__.'/tabler-stubs/webpack.mix.js', base_path('webpack.mix.js'));
 
         if (self::isLaravel57orUp()) {
-            file_put_contents(base_path('webpack.mix.js'), str_replace("assets/", "", file_get_contents(base_path('webpack.mix.js'))));
+            file_put_contents(base_path('webpack.mix.js'),
+                str_replace(
+                    "assets/",
+                    "",
+                    file_get_contents(base_path('webpack.mix.js'))
+                )
+            );
         }
  
         copy(__DIR__.'/tabler-stubs/bootstrap.js', static::getResourcePath('js/bootstrap.js'));
@@ -97,7 +103,7 @@ class TablerPreset extends Preset
     }
 
     /**
-     * Gets resource path depending on version of Laravel
+     * Gets resource path depending on version of Laravel.
      *
      * @param string $path
      * @return string

--- a/src/TablerPreset.php
+++ b/src/TablerPreset.php
@@ -61,7 +61,7 @@ class TablerPreset extends Preset
     {
         copy(__DIR__.'/tabler-stubs/webpack.mix.js', base_path('webpack.mix.js'));
 
-        if (self::isLaravel57orUp()) {
+        if (!self::expectsAssetsFolder()) {
             file_put_contents(base_path('webpack.mix.js'),
                 str_replace(
                     'assets/',
@@ -111,20 +111,20 @@ class TablerPreset extends Preset
      */
     protected static function getResourcePath($path = '')
     {
-        if (self::isLaravel57orUp()) {
-            return resource_path($path);
+        if (self::expectsAssetsFolder()) {
+            return resource_path('assets/'.$path);
         }
 
-        return resource_path('assets/'.$path);
+        return resource_path($path);
     }
 
     /**
-     * Is running in Laravel 5.7 or up?
+     * Should we expect to see an assets folder within this version of Laravel?
      *
      * @return bool
      */
-    protected static function isLaravel57orUp()
+    protected static function expectsAssetsFolder()
     {
-        return (int) str_replace('.', '', app()->version()) >= 570;
+        return (int) str_replace('.', '', app()->version()) < 570;
     }
 }

--- a/src/TablerPreset.php
+++ b/src/TablerPreset.php
@@ -64,8 +64,8 @@ class TablerPreset extends Preset
         if (self::isLaravel57orUp()) {
             file_put_contents(base_path('webpack.mix.js'),
                 str_replace(
-                    "assets/",
-                    "",
+                    'assets/',
+                    '',
                     file_get_contents(base_path('webpack.mix.js'))
                 )
             );
@@ -106,6 +106,7 @@ class TablerPreset extends Preset
      * Gets resource path depending on version of Laravel.
      *
      * @param string $path
+     *
      * @return string
      */
     protected static function getResourcePath($path = '')
@@ -115,7 +116,7 @@ class TablerPreset extends Preset
             return resource_path($path);
         }
 
-        return resource_path('assets/' . $path);
+        return resource_path('assets/'. $path);
     }
 
     /**
@@ -125,6 +126,6 @@ class TablerPreset extends Preset
      */
     protected static function isLaravel57orUp()
     {
-        return (int)str_replace('.', '', app()->version()) >= 570;
+        return (int) str_replace('.', '', app()->version()) >= 570;
     }
 }

--- a/src/TablerPreset.php
+++ b/src/TablerPreset.php
@@ -70,7 +70,7 @@ class TablerPreset extends Preset
                 )
             );
         }
- 
+
         copy(__DIR__.'/tabler-stubs/bootstrap.js', static::getResourcePath('js/bootstrap.js'));
     }
 
@@ -111,17 +111,16 @@ class TablerPreset extends Preset
      */
     protected static function getResourcePath($path = '')
     {
-
         if (self::isLaravel57orUp()) {
             return resource_path($path);
         }
 
-        return resource_path('assets/'. $path);
+        return resource_path('assets/'.$path);
     }
 
     /**
      * Is running in Laravel 5.7 or up?
-     * 
+     *
      * @return bool
      */
     protected static function isLaravel57orUp()


### PR DESCRIPTION
Fixes issue #16 - 'No support for Laravel 5.7' and replaces PR #17 - had missed 'assets/' from line 112 on TablerPreset.php which is required for 5.6 or older.

Add new method to detect Laravel version
Add new method to specify resource path depending on Laravel version
Replace resource path within webpack.mix.js depending on Laravel version