### PR TITLE
Fixed error index for email

### DIFF
--- a/src/tabler-stubs/views/auth/register.blade.php
+++ b/src/tabler-stubs/views/auth/register.blade.php
@@ -37,7 +37,7 @@
                             <label class="form-label">@lang('Email address')</label>
                             <input
                                 type="email"
-                                class="form-control{{ $errors->has('name') ? ' is-invalid' : '' }}"
+                                class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}"
                                 placeholder="Enter email"
                                 name="email"
                                 value="{{ old('email') }}"


### PR DESCRIPTION
Simple change.

When the email isn't valid (duplicated, for instance), it is not showing the correct error message in the front-end, since the index is incorrect.